### PR TITLE
Issue-11: Cannot build signaloid-soc-examples/basic-arithmetic/signaloid-soc-application/main.c using pre-built binary

### DIFF
--- a/docs/hardware-overview/signaloid-soc/compiling-applications.md
+++ b/docs/hardware-overview/signaloid-soc/compiling-applications.md
@@ -10,7 +10,11 @@ nav_order: 2
 # Compiling Applications for the Signaloid SoC
 
 ## Install the RISC-V GNU cross-compilation toolchain
-To compile applications for the built-in Signaloid SoC, you will require the open-source RISC-V GNU cross-compilation toolchain, that you can find [here](https://github.com/riscv-collab/riscv-gnu-toolchain). You can either build the cross-compilation toolchain from source, or install one of the pre-compiled binaries that you can find in the [releases](https://github.com/riscv-collab/riscv-gnu-toolchain/releases) section of the repository. Make sure to install the cross-compilation toolchain for the `RV32I` instruction set.
+To compile applications for the built-in Signaloid SoC, you will require the open-source RISC-V GNU cross-compilation toolchain, that you can find [here](https://github.com/riscv-collab/riscv-gnu-toolchain). You can build the cross-compilation toolchain from source, make sure to install it for the `RV32I` instruction set.
+
+>[!Note]
+>At the time of writing, pre-built binaries that you can find in the [releases](https://github.com/riscv-collab/riscv-gnu-toolchain/releases) section of the cross-compilation toolchain [repository](https://github.com/riscv-collab/riscv-gnu-toolchain), **do not contain** the standard C libraries compiled for the `rv32i`/`ilp32` configuration needed for the Signaloid SoC on the C0-microSD, which, if used, will result in compilation fatal errors. Please use the build guide below to build it from source.
+
 
 ### Building from source.
 You can find general installation instructions in the top-level `README.md` file of the cross-compilation toolchain [repository](https://github.com/riscv-collab/riscv-gnu-toolchain) to install it in your system. For targeting the Signaloid SoC, you must specify the target architecture to be RV32I. To do that, you must follow these steps:


### PR DESCRIPTION
Closes: #11 

**PR Highlights**
Updated the docs to make it clear that pre-built binaries found in the [releases](https://github.com/riscv-collab/riscv-gnu-toolchain/releases) section of the cross-compilation toolchain [riscv-gnu-toolchain repository](https://github.com/riscv-collab/riscv-gnu-toolchain), **do not contain** the standard C libraries needed for Signaloid SoC on the C0-microSD firmware development.